### PR TITLE
Use pip instead of Poetry in CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -17,7 +17,8 @@ jobs:
           version: 1.0.2
       - name: Install dependencies
         run: |
-          poetry install
+          poetry export -f requirements.txt -o requirements.txt
+          pip install -r requirements.txt
       - name: Test with Pytest
         run: |
-          poetry run pytest
+          pytest


### PR DESCRIPTION
Pip installs dependencies much quicker in Actions, I believe this is because there is a cache for pip specifically within the Actions datacenter.

This PR changes CI to export the poetry reqs file to pip, and then install with that.