### PR TITLE
Added jpg as LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/images/bomb-front.jpg
+++ b/images/bomb-front.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:742758302b8e371f1bd22f8066521c982f7686d410f5bfd5e17b4d5d77acbc04
+size 99232


### PR DESCRIPTION
This adds jpg images into Git Large File Storage (LFS) so that we can add any images later without increasing the repo size. The command to track other files later is:

`git lfs track "*.jpg"`

Where .jpg can be any extension.